### PR TITLE
두나무 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 * 넥스트매치 (아만다)
 * [당근마켓](https://team.daangn.com/jobs/)
 * [데브시스터즈](https://careers.devsisters.com/) (쿠키런)
-* 두나무
 * 드라마앤컴퍼니
 * [디어](https://notion.deering.co/)
 * 띵스플로우


### PR DESCRIPTION
두나무는 대기업으로 지정되어 2022년부터 산업기능요원을 받지 않습니다.

Reference: https://dunamu.com/careers/jobs/193