### PR TITLE
우아한형제들 (배달의민족) 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@
 * 오픈서베이
 * [와탭](https://www.whatap.io/ko/careers/)
 * [왓챠](https://team.watcha.com/blog/)
-* [우아한형제들](http://woowabros.github.io/) (배달의민족)
 * 위시켓
 * [조이코퍼레이션](https://zoyi.co/jobs) (채널톡, 워크인사이트)
 * 케어랩스 (굿닥, 바비톡)


### PR DESCRIPTION
메일로 문의한 결과 우아한형제들은 더이상 산업기능요원을 채용하지 않는다고 합니다.

<img width="769" alt="Screen Shot 2023-01-25 at 5 53 02 PM" src="https://user-images.githubusercontent.com/80627536/214519738-30560f93-a5a3-4e4b-97fc-641651c9e302.png">

