### PR TITLE
병역특례 '공고' 조회 사이트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * 원티드 [https://www.wanted.co.kr/search?query=%EC%82%B0%EC%97%85%EA%B8%B0%EB%8A%A5%EC%9A%94%EC%9B%90](https://www.wanted.co.kr/search?query=산업기능요원)
 * 로켓펀치 [https://www.rocketpunch.com/search?keywords=%EC%82%B0%EC%97%85%EA%B8%B0%EB%8A%A5%EC%9A%94%EC%9B%90](https://www.rocketpunch.com/search?keywords=산업기능요원)
 * 병역특례 업체 조회 [https://k-agent.services/](https://k-agent.services/)
+* 병역특례 공고 조회 [https://sangiyo.kr](https://sangiyo.kr)
 
 ### 산업기능요원을 채용하거나, 산업기능요원이 재직중인 회사
 


### PR DESCRIPTION
병역특례 '업체'가 아니라 실제로 올라온 '공고'만 모아주는 웹사이트 sangiyo.kr이 있어요. 이 사이트도 같이 소개하면 좋겠어요.

이 웹사이트는 디시인사이드 [산업기능요원 마이너 갤러리에 소개된 바 있습니다](https://gall.dcinside.com/mgallery/board/view/?id=sgy&no=45077&page=2).